### PR TITLE
Added "MIT" license text

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,4 +275,23 @@ FBI has been going after our bittie$. If you want to help, drop some penniez her
 ---
 
 # #lulzlabs
-2014 Anonymous. All Your Base Are Belong To Us. 
+Copyright (c) 2014 Anonymous. All Your Base Are Belong To Us. 
+ 
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 


### PR DESCRIPTION
Added the text for what the OSI calls the "MIT" license (FSF calls it the Expat License), as suggested here:
https://github.com/lulzlabs/AirChat/issues/18#issuecomment-446455174